### PR TITLE
Need to depend on R >= 2.10

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,7 @@ Description: The package accesses the Neotoma Paleoecological Database using
 License: CC BY-SA 3.0
 URL: https://github.com/ropensci/neotoma
 BugReports: https://github.com/ropensci/neotoma/issues
+Depends: R (>= 2.10)
 Imports:
     RJSONIO,
     RCurl (>= 1.6),


### PR DESCRIPTION
`R CMD check` indicates **neotmoa** needs to now depend on R >= 2.10, presumably because of the use of xz compression for one of the data objects.
