### PR TITLE
remove extra space at end of message

### DIFF
--- a/R/get_download.R
+++ b/R/get_download.R
@@ -80,9 +80,9 @@ get_download <- function(datasetid, verbose = TRUE){
 
     if (isTRUE(all.equal(aa[[1]], 1))) {
         aa <- aa[[2]]
-      
+
         if(verbose) {
-            writeLines(strwrap(paste("API call was successful. Returned record for ",
+            writeLines(strwrap(paste("API call was successful. Returned record for",
                                      aa$Site$SiteName)))
         }
 


### PR DESCRIPTION
Minor one. There is an extras space at the end of the first part of the new message, which when coupled with the separator in `paste` places two spaces between the strings.
