### PR TITLE
Added the changes for cf and type flags.

### DIFF
--- a/R/compile_list.R
+++ b/R/compile_list.R
@@ -56,6 +56,10 @@ compile_list <- function(object, list.name, cf = TRUE, type = TRUE){
   
   data(pollen.equiv)
   avail.lists <- c('P25', 'WS64', 'WhitmoreFull', 'WhitmoreSmall')
+  
+  if(cf == FALSE)   list.name <- list.name[is.na(pollen.equiv$cf)]
+  if(type == FALSE) list.name <- list.name[is.na(pollen.equiv$type)]
+  
   use.list <- which(avail.lists %in% list.name)
   
   if(class(object) == 'list'){


### PR DESCRIPTION
It's just a couple of `if` statements, there are columns on `pollen.equiv` that indicate whether the taxon pollen is identified as a pollen-type or cf.  This means that it is possible that the pollen is not identified correctly (or it's just caution on the part of the identifier).

In most cases the flags should stay true, but it's useful to keep them in case someone wants to get taxa defined specifically, without including _types_, perhaps for sensitivity analysis?
