### PR TITLE
document contributors in the CRAN-approved manner

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,12 @@ Type: Package
 Title: A Package to access the Neotoma Paleoecological Database using an API.
 Version: 1.0-1
 Date: 2013-04-04
-Author: Simon J. Goring
+Author: Simon J. Goring with contributions from Gavin L. Simpson, Jeremiah P. Marsicek, and Karthik Ram
+Authors@R: c(person(given = c("Simon", "J."), family = "Goring",
+    role = c("aut", "cre"), email = "goring@wisc.edu"),
+    person(given = c("Gavin", "L."), family = "Simpson", role = "ctb"),
+    person(given = c("Jeremiah", "P."), family = "Marsicek", role = "ctb"),
+    person(given = "Karthik", family = "Ram", role = "ctb"))
 Maintainer: Simon Goring <goring@wisc.edu>
 Description: The package accesses the Neotoma Paleoecological Database using
     the published API (http://api.neotomadb.org/).  The functions in this


### PR DESCRIPTION
Assuming **neotoma** is destined for CRAN, this PR updates the `DESCRIPTION` file to record the required information by CRAN Maintainer in the manner described in Writing R Extensions.

`Author` and `Maintainer` fields left in even though these can be auto filled in as the versions used here are better than the auto generated one, especially for the `Author` tag.
