### PR TITLE
add the yml to the .Rbuildignore excludes list and the README.html file

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^.*\.yml
+README\.html


### PR DESCRIPTION
This fixes a couple of new check errors because we weren't ignoring the `.yml` files nor the `README.html` file from the built source tarball.
