### PR TITLE
fixes #133; missing cl$ when referencing gpid

### DIFF
--- a/R/param_check.R
+++ b/R/param_check.R
@@ -101,7 +101,7 @@ param_check <- function(cl){
 
   #  Test the geographic identification against the Geopolitical name table.
   if ('gpid' %in% names(cl)){
-    if (is.character(gpid)){
+    if (is.character(cl$gpid)){
       data(gp.table)
       gprow <- match(x=gpid, table=gp.table$GeoPoliticalName)
       if (is.na(gprow)){
@@ -110,7 +110,7 @@ param_check <- function(cl){
       }
       gpid <- gp.table$GeoPoliticalID[gprow]
     } else {
-      if (!is.numeric(gpid)){
+      if (!is.numeric(cl$gpid)){
         error$flag <- 1
         error$message[[length(error$message) + 1]] <- 'The gpid must be either a character string or an integer.'
       }


### PR DESCRIPTION
This fixes the bug leading to behaviour reported in #133 . The two references to `gpid` should have been `cl$gpid` to reference the parameters pass in via argument `cl`.

Closes #133 when merged.
