### PR TITLE
stop R CMD check griping about too long lines in some examples.

### DIFF
--- a/R/get_download.R
+++ b/R/get_download.R
@@ -43,7 +43,8 @@
 #' #  For illustration, remove the sites with no Pseudotsuga occurance:
 #' curves <- curves[curves$count > 0, ]
 #'
-#' smooth.curve <- predict(loess(sqrt(count)~age, data=curves), data.frame(age=seq(20000, 0, by = -100)))
+#' smooth.curve <- predict(loess(sqrt(count)~age, data=curves),
+#'                         data.frame(age=seq(20000, 0, by = -100)))
 #' plot(sqrt(count) ~ age, data = curves,
 #'      ylab = '% Pseudotsuga/Larix', xlab='Calibrated Years BP', pch=19,
 #'      col=rgb(0.1, 0.1, 0.1, 0.1), xlim=c(0, 20000))

--- a/R/get_geochron.R
+++ b/R/get_geochron.R
@@ -26,8 +26,10 @@
 #'  A full data object containing all the relevant geochronological data available for a dataset.
 #' @examples \dontrun{
 #' #  Search for sites with "Pseudotsuga" pollen that are older than 8kyr BP and
-#' #  find the relevant geochronological data associated with the samples.  Are some time periods better dated than others?
-#' t8kyr.datasets <- get_dataset(taxonname='*Pseudotsuga*', loc=c(-150, 20, -100, 60), ageyoung = 8000)
+#' #  find the relevant geochronological data associated with the samples.
+#' #  Are some time periods better dated than others?
+#' t8kyr.datasets <- get_dataset(taxonname='*Pseudotsuga*', loc=c(-150, 20, -100, 60),
+#'                               ageyoung = 8000)
 #'
 #' #  Returns 74 records (as of 01/08/2014), get the dataset IDs for all records:
 #' dataset.ids <- sapply(t8kyr.datasets, function(x) x$dataset.meta$dataset.id)

--- a/man/get_download.Rd
+++ b/man/get_download.Rd
@@ -55,7 +55,8 @@ curves <- do.call(rbind.data.frame,
 #  For illustration, remove the sites with no Pseudotsuga occurance:
 curves <- curves[curves$count > 0, ]
 
-smooth.curve <- predict(loess(sqrt(count)~age, data=curves), data.frame(age=seq(20000, 0, by = -100)))
+smooth.curve <- predict(loess(sqrt(count)~age, data=curves),
+                        data.frame(age=seq(20000, 0, by = -100)))
 plot(sqrt(count) ~ age, data = curves,
      ylab = '\% Pseudotsuga/Larix', xlab='Calibrated Years BP', pch=19,
      col=rgb(0.1, 0.1, 0.1, 0.1), xlim=c(0, 20000))

--- a/man/get_geochron.Rd
+++ b/man/get_geochron.Rd
@@ -36,8 +36,10 @@ Using the dataset ID, return all geochronological data associated with the dataI
 \examples{
 \dontrun{
 #  Search for sites with "Pseudotsuga" pollen that are older than 8kyr BP and
-#  find the relevant geochronological data associated with the samples.  Are some time periods better dated than others?
-t8kyr.datasets <- get_dataset(taxonname='*Pseudotsuga*', loc=c(-150, 20, -100, 60), ageyoung = 8000)
+#  find the relevant geochronological data associated with the samples.
+#  Are some time periods better dated than others?
+t8kyr.datasets <- get_dataset(taxonname='*Pseudotsuga*', loc=c(-150, 20, -100, 60),
+                              ageyoung = 8000)
 
 #  Returns 74 records (as of 01/08/2014), get the dataset IDs for all records:
 dataset.ids <- sapply(t8kyr.datasets, function(x) x$dataset.meta$dataset.id)


### PR DESCRIPTION
This PR wraps comments and code at less than 100 characters to stop `R CMD check` from griping about truncating lines in the PDF version of the manual.
